### PR TITLE
add: ensure that Transparent Huge Pages is disabled

### DIFF
--- a/templates/default/redis.service.j2
+++ b/templates/default/redis.service.j2
@@ -6,6 +6,7 @@ Documentation=http://redis.io/documentation, man:redis-server(1)
 [Service]
 Type={{ 'forking' if redis_daemonize == 'yes' else 'simple' }}
 ExecStart={{ redis_install_dir }}/bin/redis-server /etc/redis/{{ redis_config_file_name }}
+ExecStartPre=/usr/bin/sh -c "/usr/bin/echo never | tee /sys/kernel/mm/transparent_hugepage/enabled"
 EnvironmentFile=-/etc/default/{{ redis_service_name }}
 PIDFile={{ redis_pidfile }}
 TimeoutStopSec=0


### PR DESCRIPTION
Ensure that `/sys/kernel/mm/transparent_hugepage/enabled` is set to `never` via `ExecStartPre` in the unit file.

Following the advice of the Redis developers https://redis.io/docs/management/admin/